### PR TITLE
Update NouisliderProps.tooltips typing to match noUiSlider docs

### DIFF
--- a/example/src/components/Options.js
+++ b/example/src/components/Options.js
@@ -31,7 +31,7 @@ const Options = () => (
         DIRECTION - <b>Accepted values</b> : ltr, rtl
       </li>
       <li>
-        TOOLTIPS - <b>Accepted values</b> : false, true, formatter,
+        TOOLTIPS - <b>Accepted values</b> : false, true, 
         array[formatter or true or false, ...]
       </li>
       <li>

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ export interface NouisliderProps {
     start: number | number[] | string | string[];
     step?: number;
     style?: React.CSSProperties;
-    tooltips?: boolean | object[];
+    tooltips?: boolean | (boolean | Formatter)[];
 }
 
 export default class Nouislider extends React.Component<NouisliderProps> {}

--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,9 @@ Nouislider.propTypes = {
   tooltips: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.arrayOf(
+      PropTypes.bool,
       PropTypes.shape({
+        from: PropTypes.func,
         to: PropTypes.func
       })
     )


### PR DESCRIPTION
This update changes the typings for `NouisliderProps.tooltips` to match the [noUiSlider docs](https://refreshless.com/nouislider/slider-options/#section-tooltips). I have tested these typings against `nouislider-react ^3.3.5` to ensure they pass TSlint checks and that there are no compile-time or run-time errors. I tested the `Formatter` type using `wnumb ^1.2.0` as well as a custom function that returned `to` and `from` methods.

I realized after submitting the initial pull request that the types in `index.js` needed to be updated as well as the github.io page. I've updated those files as well and ran `yarn test`, which passed all tests.