### PR TITLE
fix(#32): Fix types of formatter functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,8 +9,8 @@ interface Callback {
 }
 
 interface Formatter {
-    to(val: number): string;
-    from(val: string): number;
+    to(val: number): string | number;
+    from(val: string | number): number;
 }
 
 export interface NouisliderProps {


### PR DESCRIPTION
The formatter functions now behave as described in the documentation of noUiSlider, see [https://refreshless.com/nouislider/number-formatting/](https://refreshless.com/nouislider/number-formatting/).