### PR TITLE
Enable compatibility for IE 11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ const Nouislider = props => {
   const setClickableListeners = () => {
     if (props.clickablePips) {
       const sliderHTML = sliderContainer.current;
-      sliderHTML.querySelectorAll(".noUi-value").forEach(pip => {
+      [].slice.call(sliderHTML.querySelectorAll(".noUi-value")).forEach(pip => {
         pip.style.cursor = "pointer";
         pip.addEventListener("click", clickOnPip);
       });
@@ -117,7 +117,7 @@ const Nouislider = props => {
     return () => {
       if (slider) slider.destroy();
       if (sliderHTML) {
-        sliderHTML.querySelectorAll(".noUi-value").forEach(pip => {
+        [].slice.call(sliderHTML.querySelectorAll(".noUi-value")).forEach(pip => {
           pip.removeEventListener("click", clickOnPip);
         });
       }


### PR DESCRIPTION
Internet Explorer 11 and some other browsers [don't support calling `forEach` on a `NodeList`](https://caniuse.com/mdn-api_nodelist_foreach). Converting the `NodeList` to an array (for example via `slice`) solves the issue.