### PR TITLE
Error fix: prevent slider from being initialized more than once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,8 @@ const Nouislider = props => {
   };
 
   const createSlider = () => {
+    if (sliderContainer.current.noUiSlider) return;
+
     const sliderComponent = nouislider.create(sliderContainer.current, {
       ...props
     });


### PR DESCRIPTION
When using nouislider-react in Create React App, there is an error "Slider was already initialized".

This PR prevents the Slider from being initialized again if it has already been initialized.